### PR TITLE
fix for SDV 1.6

### DIFF
--- a/SkillPrestige.CookingSkill/ModEntry.cs
+++ b/SkillPrestige.CookingSkill/ModEntry.cs
@@ -58,7 +58,7 @@ namespace SkillPrestige.CookingSkill
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
-            this.IconTexture = helper.Content.Load<Texture2D>("assets/icon.png");
+            this.IconTexture = this.Helper.ModContent.Load<Texture2D>("assets/icon.png");
             this.SkillType = new SkillType("Cooking", 6);
             this.IsFound = helper.ModRegistry.IsLoaded(this.TargetModId);
             this.IsLuckSkillModLoaded = helper.ModRegistry.IsLoaded("alphablackwolf.LuckSkillPrestigeAdapter");

--- a/SkillPrestige.CookingSkill/SkillPrestige.CookingSkill.csproj
+++ b/SkillPrestige.CookingSkill/SkillPrestige.CookingSkill.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.2.4</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SkillPrestige.CookingSkill/manifest.json
+++ b/SkillPrestige.CookingSkill/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "Skill Prestige for Cooking Skill",
     "Author": "Alphablackwolf",
-    "Version": "1.2.4",
+    "Version": "1.2.4-unofficial.15-huancz",
     "Description": "Extends Skill Prestige to support the Cooking Skill mod.",
     "UniqueID": "Alphablackwolf.CookingSkillPrestigeAdapter",
     "EntryDll": "SkillPrestige.CookingSkill.dll",

--- a/SkillPrestige.LuckSkill/SkillPrestige.LuckSkill.csproj
+++ b/SkillPrestige.LuckSkill/SkillPrestige.LuckSkill.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.2.4</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SkillPrestige.LuckSkill/manifest.json
+++ b/SkillPrestige.LuckSkill/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "Skill Prestige for Luck Skill",
     "Author": "Alphablackwolf",
-    "Version": "1.2.4",
+    "Version": "1.2.4-unofficial.15-huancz",
     "Description": "Extends Skill Prestige to support the Luck Skill mod.",
     "UniqueID": "alphablackwolf.LuckSkillPrestigeAdapter",
     "EntryDll": "SkillPrestige.LuckSkill.dll",

--- a/SkillPrestige.Magic/ModEntry.cs
+++ b/SkillPrestige.Magic/ModEntry.cs
@@ -68,7 +68,7 @@ namespace SkillPrestige.Magic
         /// <param name="helper">Provides simplified APIs for writing mods.</param>
         public override void Entry(IModHelper helper)
         {
-            this.IconTexture = helper.Content.Load<Texture2D>("assets/icon.png");
+            this.IconTexture = helper.ModContent.Load<Texture2D>("assets/icon.png");
             this.MagicSkillType = new SkillType("Magic", 8);
             this.IsFound = helper.ModRegistry.IsLoaded(this.MagicModId);
             this.IsCookingSkillModLoaded = helper.ModRegistry.IsLoaded("Alphablackwolf.CookingSkillPrestigeAdapter");

--- a/SkillPrestige.Magic/SkillPrestige.Magic.csproj
+++ b/SkillPrestige.Magic/SkillPrestige.Magic.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.2.4</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <Reference Include="Magic" HintPath="$(GamePath)\Mods\Magic\Magic.dll" Private="False" />
+    <Reference Include="ManaBar" HintPath="$(GamePath)\Mods\ManaBar\ManaBar.dll" Private="False" />
     <Reference Include="SpaceCore" HintPath="$(GamePath)\Mods\SpaceCore\SpaceCore.dll" Private="False" />
   </ItemGroup>
 </Project>

--- a/SkillPrestige.Magic/manifest.json
+++ b/SkillPrestige.Magic/manifest.json
@@ -1,7 +1,7 @@
 {
     "Name": "Skill Prestige for Magic",
     "Author": "Alphablackwolf",
-    "Version": "1.2.4",
+    "Version": "1.2.4-unofficial.15-huancz",
     "Description": "Extends Skill Prestige to support the Magic mod.",
     "UniqueID": "alphablackwolf.MagicPrestigeAdapter",
     "EntryDll": "SkillPrestige.Magic.dll",

--- a/SkillPrestige/Framework/Commands/ResetAllProfessionsCommand.cs
+++ b/SkillPrestige/Framework/Commands/ResetAllProfessionsCommand.cs
@@ -68,7 +68,10 @@ namespace SkillPrestige.Framework.Commands
                 .Select(prof => prof.SpecialHandling);
 
             Game1.player.professions.Clear();
-            Game1.player.professions.AddRange(professionsToKeep.Select(x => x.Id));
+            foreach (var profession in professionsToKeep)
+            {
+                Game1.player.professions.Add(profession.Id);
+            }
             foreach (var specialHandling in specialHandlingsForSkillsRemoved)
                 specialHandling.RemoveEffect();
             Logger.LogInformation("Professions reset.");

--- a/SkillPrestige/SkillPrestige.csproj
+++ b/SkillPrestige/SkillPrestige.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.2.4</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="JsonNet.PrivateSettersContractResolvers.Source" Version="0.1.0" IncludeAssets="runtime; build; native; contentfiles; analyzers" PrivateAssets="all" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
   </ItemGroup>
 </Project>

--- a/SkillPrestige/manifest.json
+++ b/SkillPrestige/manifest.json
@@ -1,10 +1,10 @@
 {
     "Name": "Skill Prestige",
     "Author": "Alphablackwolf",
-    "Version": "1.2.4",
+    "Version": "1.2.4-unofficial.15-huancz",
     "Description": "Lets you earn permanent profession perks beyond that which can normally be obtained in Vanilla play by spending Prestige Points, earned by resetting a skill from 10 to 0.",
     "UniqueID": "alphablackwolf.skillPrestige",
     "EntryDll": "SkillPrestige.dll",
-    "MinimumApiVersion": "3.1.0",
+    "MinimumApiVersion": "4.0.0",
     "UpdateKeys": [ "Nexus:569" ]
 }

--- a/UnitTests/ExtensionTests.cs
+++ b/UnitTests/ExtensionTests.cs
@@ -9,9 +9,9 @@ namespace SkillPrestige.UnitTests
         public void SetInstanceFieldOfBase_SetsPrivateBaseClassProperty()
         {
             var item = new DerivedClass();
-            Assert.IsTrue(item.GetCost == 2);
+            Assert.That(item.GetCost == 2);
             item.SetProperty();
-            Assert.IsTrue(item.GetCost == 5);
+            Assert.That(item.GetCost == 5);
         }
 
         private class BaseClass

--- a/UnitTests/SkillTests.cs
+++ b/UnitTests/SkillTests.cs
@@ -12,24 +12,24 @@ namespace SkillPrestige.UnitTests
         {
             var skillType = new SkillType();
             // ReSharper disable once EqualExpressionComparison - checking for equals comparison override.
-            Assert.IsTrue(skillType.Equals(skillType));
+            Assert.That(skillType.Equals(skillType));
             var skillType2 = skillType;
-            Assert.IsTrue(skillType == skillType2);
+            Assert.That(skillType == skillType2);
         }
 
         [Test]
         public void SkillType_EqualsSameDefinedSkillType_ReturnsTrue()
         {
             var skillType = SkillType.Mining;
-            Assert.IsTrue(skillType.Equals(SkillType.Mining));
-            Assert.IsTrue(skillType == SkillType.Mining);
+            Assert.That(skillType.Equals(SkillType.Mining));
+            Assert.That(skillType == SkillType.Mining);
         }
 
         [Test]
         public void AllSkills_ContainsSkills_ReturnsTrue()
         {
             var skillType = SkillType.Mining;
-            Assert.IsTrue(Skill.AllSkills.Select(x => x.Type).Contains(skillType));
+            Assert.That(Skill.AllSkills.Select(x => x.Type).Contains(skillType));
             // ReSharper disable once ReturnValueOfPureMethodIsNotUsed - testing that the line does not throw an exception
             Assert.DoesNotThrow(delegate { Skill.AllSkills.Single(x => x.Type == skillType); });
         }

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <EnableModDeploy>false</EnableModDeploy>
     <EnableModZip>false</EnableModZip>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.5.22" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="NUnit" Version="3.4.1" />
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.3.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
main mod tested a little. Skill adapters for luck, magic and cooking skills build, but their respective mods are rejected by SMAPI => not tested.

Also closes dependabot PRs.