### PR TITLE
using the GameModPath instead of GamePath for mod paths

### DIFF
--- a/SkillPrestige.CookingSkill/SkillPrestige.CookingSkill.csproj
+++ b/SkillPrestige.CookingSkill/SkillPrestige.CookingSkill.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="CookingSkill" HintPath="$(GamePath)\Mods\CookingSkill\CookingSkill.dll" Private="False" />
-    <Reference Include="SpaceCore" HintPath="$(GamePath)\Mods\SpaceCore\SpaceCore.dll" Private="False" />
+    <Reference Include="CookingSkill" HintPath="$(GameModsPath)\CookingSkill\CookingSkill.dll" Private="False" />
+    <Reference Include="SpaceCore" HintPath="$(GameModsPath)\SpaceCore\SpaceCore.dll" Private="False" />
   </ItemGroup>
 </Project>

--- a/SkillPrestige.LuckSkill/SkillPrestige.LuckSkill.csproj
+++ b/SkillPrestige.LuckSkill/SkillPrestige.LuckSkill.csproj
@@ -13,6 +13,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="LuckSkill" HintPath="$(GamePath)\Mods\LuckSkill\LuckSkill.dll" Private="False" />
+    <Reference Include="LuckSkill" HintPath="$(GameModsPath)\LuckSkill\LuckSkill.dll" Private="False" />
   </ItemGroup>
 </Project>

--- a/SkillPrestige.Yacs/SkillPrestige.Yacs.csproj
+++ b/SkillPrestige.Yacs/SkillPrestige.Yacs.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="CookingSkill" HintPath="$(GamePath)\Mods\CookingSkill\CookingSkillCode\CookingSkillCode.dll" Private="False" />
-    <Reference Include="SpaceCore" HintPath="$(GamePath)\Mods\SpaceCore\SpaceCore.dll" />
+    <Reference Include="CookingSkill" HintPath="$(GameModsPath)\CookingSkill\CookingSkillCode\CookingSkillCode.dll" Private="False" />
+    <Reference Include="SpaceCore" HintPath="$(GameModsPath)\SpaceCore\SpaceCore.dll" />
   </ItemGroup>
 
 </Project>

--- a/SkillPrestige/SkillPrestige.csproj
+++ b/SkillPrestige/SkillPrestige.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Reference Include="SpaceCore" HintPath="$(GamePath)\Mods\SpaceCore\SpaceCore.dll" Private="False" />
+    <Reference Include="SpaceCore" HintPath="$(GameModsPath)\SpaceCore\SpaceCore.dll" Private="False" />
   </ItemGroup>
 
   <Target Name="DeployPack" AfterTargets="Build">


### PR DESCRIPTION
This pr just changes the paths for the mod paths.
SMAPI has a separate variable for the mod path from the one for the game path.
In most cases this doesn't matter, however when using the stardrop mod manager, all mods are in a subdir.
This change allows setting that subdir in the global stardew valley target file and still have the mod compile.
In case that variable is not overwritten it is set to (GamePath)/Mods so this shouldn't cause unexpected regressions.